### PR TITLE
Correct auth_domain variable prefix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ EOF
         user_pool_arn = aws_cognito_user_pool.mypool.arn
         user_pool_id = aws_cognito_user_pool.mypool.id
         client_id = aws_cognito_user_pool_client.myclient.id
-        auth_domain = "https://mydomain.auth.eu-west-1.amazoncognito.com"
+        auth_domain = "mydomain.auth.eu-west-1.amazoncognito.com"
     }
   
     # Optional

--- a/website.tf
+++ b/website.tf
@@ -86,7 +86,17 @@ resource "aws_s3_bucket" "website" {
   bucket        = "${lower(var.deployment_name)}-website-files"
   force_destroy = true
 }
+
+resource "aws_s3_bucket_ownership_controls" "website" {
+  bucket = aws_s3_bucket.website.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "website" {
+  depends_on = [aws_s3_bucket_ownership_controls.website]
+
   bucket = aws_s3_bucket.website.id
   acl    = "private"
 }
@@ -106,8 +116,20 @@ resource "aws_s3_bucket" "data" {
   bucket        = "${lower(var.deployment_name)}-website-data"
   force_destroy = false
 }
+
+resource "aws_s3_bucket_ownership_controls" "data" {
+  count = var.create_data_bucket ? 1 : 0
+
+  bucket = aws_s3_bucket.data[count.index].id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+
 resource "aws_s3_bucket_acl" "data" {
   count = var.create_data_bucket ? 1 : 0
+  depends_on = [aws_s3_bucket_ownership_controls.data]
 
   bucket = aws_s3_bucket.data[count.index].id
   acl    = "private"


### PR DESCRIPTION
The `auth domain` variable must be written without https, as the variable that references it already has https.