### PR TITLE
Correct AccessControlListNotSupported error

### DIFF
--- a/website.tf
+++ b/website.tf
@@ -86,7 +86,17 @@ resource "aws_s3_bucket" "website" {
   bucket        = "${lower(var.deployment_name)}-website-files"
   force_destroy = true
 }
+
+resource "aws_s3_bucket_ownership_controls" "website" {
+  bucket = aws_s3_bucket.website.id
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
+
 resource "aws_s3_bucket_acl" "website" {
+  depends_on = [aws_s3_bucket_ownership_controls.website]
+
   bucket = aws_s3_bucket.website.id
   acl    = "private"
 }
@@ -106,8 +116,20 @@ resource "aws_s3_bucket" "data" {
   bucket        = "${lower(var.deployment_name)}-website-data"
   force_destroy = false
 }
+
+resource "aws_s3_bucket_ownership_controls" "data" {
+  count = var.create_data_bucket ? 1 : 0
+
+  bucket = aws_s3_bucket.data[count.index].id
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
+
+
 resource "aws_s3_bucket_acl" "data" {
   count = var.create_data_bucket ? 1 : 0
+  depends_on = [aws_s3_bucket_ownership_controls.data]
 
   bucket = aws_s3_bucket.data[count.index].id
   acl    = "private"


### PR DESCRIPTION
I've came up with the following error after creating the bucket, destroying it and trying to recreate it again:

> │ Error: error creating S3 bucket ACL for ***-website-files: AccessControlListNotSupported: The bucket does not allow ACLs
│ 	status code: 400
│ 
│   with module.website.aws_s3_bucket_acl.website,
│   on .terraform/modules/website/website.tf line 89, in resource "aws_s3_bucket_acl" "website":
│   89: resource "aws_s3_bucket_acl" "website" {

After taking a look, I found this example within the documentation, that after using it with "Object writer" and applying to the code, solved the issue.
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl

PS: I couldn't test the use of this strucutre with the data bucket. However, as the structure is very simular with the website bucket, I extended its use.